### PR TITLE
add support for generic knot types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bspline"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Will Usher <will@willusher.io>"]
 description = "A simple generic library for computing B-splines"
 homepage = "https://github.com/Twinklebear/bspline"
@@ -15,6 +15,9 @@ exclude = [
 	"./*.png",
 	".gitignore",
 ]
+
+[dependencies]
+num-traits = "0.2"
 
 [dev-dependencies]
 image = "0.21.2"

--- a/examples/logo.rs
+++ b/examples/logo.rs
@@ -114,7 +114,7 @@ impl IndexMut<usize> for Colorf {
 
 /// Evaluate the B-spline and plot it to the image buffer passed. The colors and points splines
 /// should have the same t range.
-fn plot_2d(spline: &bspline::BSpline<Point>, colors: &bspline::BSpline<Colorf>, plot: &mut [u8],
+fn plot_2d(spline: &bspline::BSpline<Point, f32>, colors: &bspline::BSpline<Colorf, f32>, plot: &mut [u8],
            plot_dim: (usize, usize), scale: (f32, f32), offset: (f32, f32), show_control_pts: bool) {
     let step_size = 0.001;
     let t_range = spline.knot_domain();

--- a/examples/plot1d.rs
+++ b/examples/plot1d.rs
@@ -4,7 +4,7 @@ extern crate bspline;
 use std::iter;
 
 /// Evaluate the B-spline and plot it to the image buffer passed
-fn plot_1d(spline: &bspline::BSpline<f32>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
+fn plot_1d(spline: &bspline::BSpline<f32, f32>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
            offset: (f32, f32)) {
     let step_size = 0.001;
     let t_range = spline.knot_domain();

--- a/examples/plot2d.rs
+++ b/examples/plot2d.rs
@@ -28,7 +28,7 @@ impl Add for Point {
 }
 
 /// Evaluate the B-spline and plot it to the image buffer passed
-fn plot_2d(spline: &bspline::BSpline<Point>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
+fn plot_2d(spline: &bspline::BSpline<Point, f32>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
            offset: (f32, f32)) {
     let step_size = 0.001;
     let t_range = spline.knot_domain();

--- a/tests/test2d.rs
+++ b/tests/test2d.rs
@@ -28,7 +28,7 @@ impl Add for Point {
 }
 
 /// Evaluate the B-spline and plot it to the image buffer passed
-fn plot_2d(spline: &bspline::BSpline<Point>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
+fn plot_2d(spline: &bspline::BSpline<Point, f32>, plot: &mut [u8], plot_dim: (usize, usize), scale: (f32, f32),
            offset: (f32, f32)) {
     let step_size = 0.001;
     let t_range = spline.knot_domain();


### PR DESCRIPTION
Hi

Thanks for the awesome B-Spline library! It has been super useful for me recently :)

However, I found the fact that knots were forced to be `f32` types a bit constraining so I've made a couple of changes in this MR to enable knots to be of any type that implements the [num_traits::Float](https://docs.rs/num-traits/0.2.14/num_traits/float/trait.Float.html) i.e. `f32`, `f64` and whatever specific float-like types are out there. I have also modified all existing examples to be of forced `f32` type to maintain backwards compatibility and added a specific `f64` test in the core library.

I also took the liberty to increment the library version but feel free to revert that if you think it is unnecessary.

PS. I also thought about forcing control points and knots to have the same type but I thought that introduced other limitations so I decided to not do that.