### PR TITLE
nalgebra support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bspline"
-version = "0.2.4"
+version = "1.1.0"
 authors = ["Will Usher <will@willusher.io>"]
 description = "A simple generic library for computing B-splines"
 homepage = "https://github.com/Twinklebear/bspline"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,14 @@ exclude = [
 	".gitignore",
 ]
 
+[features]
+nalgebra-support = ["nalgebra"]
+
 [dependencies]
-nalgebra = "0.27"
+num-traits = "0.2"
+trait-set = "0.2"
+nalgebra = { version = "0.3", optional=true}
 
 [dev-dependencies]
-image = "0.21.2"
+image = "0.22"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-nalgebra = "0.23"
+nalgebra = "0.25"
 
 [dev-dependencies]
 image = "0.21.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-num-traits = "0.2"
+nalgebra = "0.26"
 
 [dev-dependencies]
 image = "0.21.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-nalgebra = "0.26"
+nalgebra = "0.23"
 
 [dev-dependencies]
 image = "0.21.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-nalgebra = "0.25"
+nalgebra = "0.27"
 
 [dev-dependencies]
 image = "0.21.2"

--- a/README.md
+++ b/README.md
@@ -47,3 +47,16 @@ effectively use this library can be found below.
 - [Geometric Modeling](http://atrey.karlin.mff.cuni.cz/projekty/vrr/doc/grafika/geometric%20modelling.pdf)
 - [A nice set of interactive examples](https://www.ibiblio.org/e-notes/Splines/Intro.htm)
 
+# nalgebra support
+
+[nalgerba](https://docs.rs/nalgebra/latest/nalgebra/) is one of the most popular linear algbera packages for Rust. To make this create compatible with it, you need to enable the `nalgebra-support` feature and then you can recreate the above example:
+
+```rust
+use nalgebra as na;
+
+let points = na::DVector::from(vec![0.0, 0.0, 0.0, 6.0, 0.0, 0.0, 0.0])
+let knots = na::DVector::from(vec![-2.0, -2.0, -2.0, -2.0, -1.0, 0.0, 1.0, 2.0, 2.0, 2.0, 2.0]);
+let degree = 3;
+let spline = bspline::BSpline::new(degree, points, knots);
+```
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 
 use std::ops::{Mul, Add};
 use std::slice::Iter;
-extern crate num_traits;
-use num_traits::{Float, One};
+extern crate nalgebra;
+use nalgebra::RealField;
 
 /// The interpolate trait is used to linearly interpolate between two types (or in the
 /// case of Quaternions, spherically linearly interpolate). The B-spline curve uses this
@@ -65,17 +65,16 @@ pub trait Interpolate<F> {
     fn interpolate(&self, other: &Self, t: F) -> Self;
 }
 
-impl<T: Mul<F, Output = T> + Add<Output = T> + Copy, F: Float> Interpolate<F> for T {
+impl<T: Mul<F, Output = T> + Add<Output = T> + Copy, F: RealField> Interpolate<F> for T {
     fn interpolate(&self, other: &Self, t: F) -> Self {
-        let one: F = One::one();
-        *self * (one - t) + *other * t
+        *self * (F::one() - t) + *other * t
     }
 }
 
 /// Represents a B-spline curve that will use polynomials of the specified degree
 /// to interpolate between the control points given the knots.
 #[derive(Clone, Debug)]
-pub struct BSpline<T: Interpolate<F> + Copy, F: Float> {
+pub struct BSpline<T: Interpolate<F> + Copy, F: RealField> {
     /// Degree of the polynomial that we use to make the curve segments
     degree: usize,
     /// Control points for the curve
@@ -84,7 +83,7 @@ pub struct BSpline<T: Interpolate<F> + Copy, F: Float> {
     knots: Vec<F>,
 }
 
-impl<T: Interpolate<F> + Copy, F: Float> BSpline<T, F> {
+impl<T: Interpolate<F> + Copy, F: RealField> BSpline<T, F> {
     /// Create a new B-spline curve of the desired `degree` that will interpolate
     /// the `control_points` using the `knots`. The knots should be sorted in non-decreasing
     /// order otherwise they will be sorted for you, which may lead to undesired knots
@@ -152,7 +151,7 @@ impl<T: Interpolate<F> + Copy, F: Float> BSpline<T, F> {
             for j in 0..self.degree - lvl {
                 let i = j + k + i_start - self.degree;
                 let alpha = (t - self.knots[i - 1]) / (self.knots[i + self.degree - k] - self.knots[i - 1]);
-                debug_assert!(!alpha.is_nan());
+                debug_assert!(alpha.is_finite());
                 tmp[j] = tmp[j].interpolate(&tmp[j + 1], alpha);
             }
         }
@@ -163,7 +162,7 @@ impl<T: Interpolate<F> + Copy, F: Float> BSpline<T, F> {
 /// Return the index of the first element greater than the value passed.
 /// The data **must** be sorted. If no element greater than the value
 /// passed is found the function returns None.
-fn upper_bounds<F: Float>(data: &[F], value: F) -> Option<usize> {
+fn upper_bounds<F: RealField>(data: &[F], value: F) -> Option<usize> {
     let mut first = 0usize;
     let mut step;
     let mut count = data.len() as isize;
@@ -188,11 +187,11 @@ fn upper_bounds<F: Float>(data: &[F], value: F) -> Option<usize> {
 #[cfg(test)]
 mod test {
     use super::BSpline;
-    use num_traits::Float;
+    use nalgebra::RealField;
     use std::ops::{Mul, Add};
 
     /// Check that the bspline returns the values we expect it to at various t values
-    fn check_bspline<T: Mul<F, Output = T> + Add<Output = T> + Copy + PartialOrd, F: Float>(spline: &BSpline<T, F>, expect: &Vec<(F, T)>) -> bool {
+    fn check_bspline<T: Mul<F, Output = T> + Add<Output = T> + Copy + PartialOrd, F: RealField>(spline: &BSpline<T, F>, expect: &Vec<(F, T)>) -> bool {
         expect.iter().fold(true, |ac, &(t, x)| ac && spline.point(t) == x)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 use std::ops::{Mul, Add};
 use std::slice::Iter;
 extern crate nalgebra;
-use nalgebra::RealField;
+use nalgebra as na;
 
 /// The interpolate trait is used to linearly interpolate between two types (or in the
 /// case of Quaternions, spherically linearly interpolate). The B-spline curve uses this
@@ -65,7 +65,7 @@ pub trait Interpolate<F> {
     fn interpolate(&self, other: &Self, t: F) -> Self;
 }
 
-impl<T: Mul<F, Output = T> + Add<Output = T> + Copy, F: RealField> Interpolate<F> for T {
+impl<T: Mul<F, Output = T> + Add<Output = T> + Copy, F: na::RealField> Interpolate<F> for T {
     fn interpolate(&self, other: &Self, t: F) -> Self {
         *self * (F::one() - t) + *other * t
     }
@@ -74,7 +74,7 @@ impl<T: Mul<F, Output = T> + Add<Output = T> + Copy, F: RealField> Interpolate<F
 /// Represents a B-spline curve that will use polynomials of the specified degree
 /// to interpolate between the control points given the knots.
 #[derive(Clone, Debug)]
-pub struct BSpline<T: Interpolate<F> + Copy, F: RealField> {
+pub struct BSpline<T: Interpolate<F> + Copy, F: na::RealField> {
     /// Degree of the polynomial that we use to make the curve segments
     degree: usize,
     /// Control points for the curve
@@ -83,7 +83,7 @@ pub struct BSpline<T: Interpolate<F> + Copy, F: RealField> {
     knots: Vec<F>,
 }
 
-impl<T: Interpolate<F> + Copy, F: RealField> BSpline<T, F> {
+impl<T: Interpolate<F> + Copy, F: na::RealField> BSpline<T, F> {
     /// Create a new B-spline curve of the desired `degree` that will interpolate
     /// the `control_points` using the `knots`. The knots should be sorted in non-decreasing
     /// order otherwise they will be sorted for you, which may lead to undesired knots
@@ -162,7 +162,7 @@ impl<T: Interpolate<F> + Copy, F: RealField> BSpline<T, F> {
 /// Return the index of the first element greater than the value passed.
 /// The data **must** be sorted. If no element greater than the value
 /// passed is found the function returns None.
-fn upper_bounds<F: RealField>(data: &[F], value: F) -> Option<usize> {
+fn upper_bounds<F: na::RealField>(data: &[F], value: F) -> Option<usize> {
     let mut first = 0usize;
     let mut step;
     let mut count = data.len() as isize;
@@ -187,11 +187,11 @@ fn upper_bounds<F: RealField>(data: &[F], value: F) -> Option<usize> {
 #[cfg(test)]
 mod test {
     use super::BSpline;
-    use nalgebra::RealField;
+    use nalgebra as na;
     use std::ops::{Mul, Add};
 
     /// Check that the bspline returns the values we expect it to at various t values
-    fn check_bspline<T: Mul<F, Output = T> + Add<Output = T> + Copy + PartialOrd, F: RealField>(spline: &BSpline<T, F>, expect: &Vec<(F, T)>) -> bool {
+    fn check_bspline<T: Mul<F, Output = T> + Add<Output = T> + Copy + PartialOrd, F: na::RealField>(spline: &BSpline<T, F>, expect: &Vec<(F, T)>) -> bool {
         expect.iter().fold(true, |ac, &(t, x)| ac && spline.point(t) == x)
     }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,126 @@
+extern crate bspline;
+use bspline::BSpline;
+use std::ops::{Add, Mul};
+extern crate trait_set;
+use trait_set::trait_set;
+extern crate num_traits;
+trait_set! {
+    pub trait Float = num_traits::Float;
+}
+
+#[cfg(feature = "nalgebra-support")]
+extern crate nalgebra;
+#[cfg(feature = "nalgebra-support")]
+trait_set! {
+    pub trait Float = nalgebra::RealField;
+}
+
+/// Check that the bspline returns the values we expect it to at various t values
+fn check_bspline<T: Mul<F, Output = T> + Add<Output = T> + Copy + PartialOrd, F: Float>(
+    spline: &BSpline<T, F>,
+    expect: &Vec<(F, T)>,
+) -> bool {
+    expect
+        .iter()
+        .fold(true, |ac, &(t, x)| ac && spline.point(t) == x)
+}
+
+#[test]
+fn linear_bspline() {
+    let expect: Vec<(f32, f32)> = vec![
+        (0.0, 0.0),
+        (0.2, 0.2),
+        (0.4, 0.4),
+        (0.6, 0.6),
+        (0.8, 0.8),
+        (1.0, 1.0),
+    ];
+    let points: Vec<f32> = vec![0.0, 1.0];
+    let knots: Vec<f32> = vec![0.0, 0.0, 1.0, 1.0];
+    let degree = 1;
+    let spline = BSpline::new(degree, points, knots);
+    assert!(check_bspline(&spline, &expect));
+}
+#[test]
+fn quadratic_bspline() {
+    let expect: Vec<(f32, f32)> = vec![
+        (0.0, 0.0),
+        (0.5, 0.125),
+        (1.0, 0.5),
+        (1.4, 0.74),
+        (1.5, 0.75),
+        (1.6, 0.74),
+        (2.0, 0.5),
+        (2.5, 0.125),
+        (3.0, 0.0),
+    ];
+    let points: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0];
+    let knots: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0];
+    let degree = 2;
+    let spline = BSpline::new(degree, points, knots);
+    assert!(check_bspline(&spline, &expect));
+}
+#[test]
+fn cubic_bspline() {
+    let expect: Vec<(f32, f32)> = vec![
+        (-2.0, 0.0),
+        (-1.5, 0.125),
+        (-1.0, 1.0),
+        (-0.6, 2.488),
+        (0.0, 4.0),
+        (0.5, 2.875),
+        (1.5, 0.12500001),
+        (2.0, 0.0),
+    ];
+    let points: Vec<f32> = vec![0.0, 0.0, 0.0, 6.0, 0.0, 0.0, 0.0];
+    let knots: Vec<f32> = vec![-2.0, -2.0, -2.0, -2.0, -1.0, 0.0, 1.0, 2.0, 2.0, 2.0, 2.0];
+    let degree = 3;
+    let spline = BSpline::new(degree, points, knots);
+    assert!(check_bspline(&spline, &expect));
+}
+#[test]
+fn quartic_bspline() {
+    let expect: Vec<(f32, f32)> = vec![
+        (0.0, 0.0),
+        (0.4, 0.0010666668),
+        (1.0, 0.041666668),
+        (1.5, 0.19791667),
+        (2.0, 0.4583333),
+        (2.5, 0.5989583),
+        (3.0, 0.4583333),
+        (3.2, 0.35206667),
+        (4.1, 0.02733751),
+        (4.5, 0.002604167),
+        (5.0, 0.0),
+    ];
+    let points: Vec<f32> = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0];
+    let knots: Vec<f32> = vec![
+        0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+    ];
+    let degree = 4;
+    let spline = BSpline::new(degree, points, knots);
+    assert!(check_bspline(&spline, &expect));
+}
+#[test]
+fn quartic_bspline_f64() {
+    let expect: Vec<(f64, f64)> = vec![
+        (0.0, 0.0),
+        (0.4, 0.001066666666666667),
+        (1.0, 0.041666666666666664),
+        (1.5, 0.19791666666666666),
+        (2.0, 0.45833333333333337),
+        (2.5, 0.5989583333333334),
+        (3.0, 0.4583333333333333),
+        (3.2, 0.3520666666666666),
+        (4.1, 0.027337500000000046),
+        (4.5, 0.002604166666666666),
+        (5.0, 0.0),
+    ];
+    let points: Vec<f64> = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0];
+    let knots: Vec<f64> = vec![
+        0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+    ];
+    let degree = 4;
+    let spline = BSpline::new(degree, points, knots);
+    assert!(check_bspline(&spline, &expect));
+}


### PR DESCRIPTION
Part PR, part discussion how to best do this

A while ago when I was using this awesome crate, I couldn't get it to natively work with nalgebra. The fault is possibly nalgebra's because it doesn't support the more generic `num_traits` crate. Regardless of that, I'd love to just be able to use this crate directly so I'm opening this PR. However, I am not sure if it is the best idea to force `bspline` users to use `nalgebra` since it also limits. I was thinking maybe it would be best to add an `nalgebra` feature to this crate which when enabled, swaps out `num_traits` for `nalgebra`. What do you think?   